### PR TITLE
Fixing problem with Kong Konnect DCR Verification Process and Enhancing the Kubernetes Deployment example

### DIFF
--- a/kubernetes/konnect-keycloak-portal-dcr.yaml
+++ b/kubernetes/konnect-keycloak-portal-dcr.yaml
@@ -1,3 +1,18 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sec-konnect-keycloak-portal-dcr
+  labels:
+    app: konnect-portal-dcr-keycloak
+type: Opaque
+stringData:
+  KEYCLOAK_CR_INITIAL_AT: "<initial_at-to-be-replaced>"
+  KEYCLOAK_CLIENT_ID: "kong-sa"
+  KEYCLOAK_CLIENT_SECRET: "<kong-sa-client_secret-to-be-replaced>"
+  KEYCLOAK_DOMAIN: "<keycloak-domain-to-be-replaced>"
+  KONG_API_TOKENS: "<your_Konnect_API_Key_value>"
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/src/schemas/ApplicationPayload.ts
+++ b/src/schemas/ApplicationPayload.ts
@@ -34,8 +34,10 @@ export const ApplicationPayloadSchema = {
       type: 'string'
     },
     portal_id: {
-      type: 'string',
-      format: 'uuid'
+      oneOf: [
+        { type: 'string', format: 'uuid' },
+        { type: 'string', const: 'test portal_id' }
+      ]
     },
     organization_id: {
       type: 'string',


### PR DESCRIPTION
This PR fixes an issue where the DCR Provider verification process currently sends `test portal_id` rather than a real UUID formatted string.

Additionally this PR enhances the Kubernetes deployment example to show an example secret configuration in which the original example contained an example where a secret was referenced, but not illustrated.