### PR TITLE
Fix: use kong-sa service-account token for client creation instead of consumable IAT

### DIFF
--- a/.env.dockerfile
+++ b/.env.dockerfile
@@ -3,11 +3,10 @@
 # environment variables with this static file but at the runtime
 #----------------------------------------------------------------
 
-# 'client' creation => use Client Registration Initial Access Token
-# KEYCLOAK_CR_INITIAL_AT=
-
-# 'client' deletion and refresh token => use client_id / client_secret 
+# 'client' creation, deletion and refresh token => use client_id / client_secret
+# of the `kong-sa` service account (which holds the `create-client` role)
 # KEYCLOAK_CLIENT_ID=
+# KEYCLOAK_CLIENT_SECRET=
 
 ## The base domain for the Identity Provider
 # KEYCLOAK_DOMAIN=

--- a/.env.test
+++ b/.env.test
@@ -1,6 +1,7 @@
-## The token for the third party Identity Provider
-OKTA_API_TOKEN=atoken
+## The `kong-sa` service-account client used for all Keycloak operations
+KEYCLOAK_CLIENT_ID=kong-sa
+KEYCLOAK_CLIENT_SECRET=atestsecret
 ## The base domain for the Identity Provider
-KEYCLOAK_DOMAIN=https://dev-something.okta.com/
+KEYCLOAK_DOMAIN=https://sso.example.com/auth/realms/test/
 ## Comma-separated tokens from Konnect
 KONG_API_TOKENS=oldtoken,newtoken

--- a/README.md
+++ b/README.md
@@ -237,6 +237,18 @@ HTTP/1.1 204 No Content
 ```
 Check on Keycloak the deletion of this `client`
 
+### Automated tests
+Unit tests (mocked Keycloak, no Docker required):
+```shell
+npm test
+```
+
+Integration tests against a **live Keycloak** instance. These spin up Keycloak in Docker, provision a `dcr-test` realm and the `kong-sa` service-account client (with the `create-client` role), then drive the real bridge to register several clients in a row — the regression test for the previous Initial Access Token (IAT) exhaustion issue. Requires a running Docker daemon plus `curl` and `jq`:
+```shell
+npm run test:integration
+```
+The harness lives in [test/integration/](test/integration/): `setup-keycloak.sh` provisions Keycloak and prints the bridge environment, `run.sh` ties setup → tests → teardown together, and `teardown-keycloak.sh` removes the container. Set `KEEP_KEYCLOAK=1` to leave the container running between runs. The integration suite skips itself automatically when the live Keycloak environment variables are absent, so `npm test` and CI without Docker are unaffected.
+
 ### Deploy the bridge on AWS Lambda Function
 - The Git Workflow [ci.yml](.github/workflows/ci.yml) pushes the DCR Handler code in the Lambda Function.
 - Prepare and start a `self-hosted` Github Runner: open with the browser your Github repo and select Settings / Actions / Runners and click on `New self-hosted runner` 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,10 @@ Install [Httpie](https://httpie.io/cli)
 Prepare a random and strong key that is used by Konnect to authenticate with the HTTP DCR bridge. In the rest of the document this key is refered to as `your_Konnect_API_Key_value`
 
 ### Keycloak configuration
-1) Create an `Initial Access Token` for managing (from Konnect Dev Portal) the Application creation and **store the Initial AT**
-![Alt text](/images/1-keycloak-Client-Registration-Initial-AT.png?raw=true "Client Registration Initial Access Token")
+1) Create a `client`, called it for instance `kong-sa`, for managing (from Konnect Dev Portal) the application creation, the application deletion and the refresh token action.
 
-2) Create a `client`, called it for instance `kong-sa`, for managing (from Konnect Dev Portal) the application  deletion and the refresh token action. 
+> **Note:** earlier versions of this bridge used a Client Registration `Initial Access Token` (IAT) for the application creation. An IAT is a *consumable* bootstrap credential: Keycloak decrements its **Count** on every registration and it stops working once the count is exhausted or it expires, returning `401 Unauthorized`. The bridge now mints a short-lived service-account token from the `kong-sa` client (which holds the `create-client` role) for **every** call, so no IAT is required and there is nothing to expire.
+
 The properties are:
   - Client Protocol = `openid-connect`
   - Access Type = `confidential`
@@ -44,7 +44,7 @@ The properties are:
 
 **Click on Save**
 
-3) Open the `kong-sa` client, select `Service Account Roles` tab, select in `Client Roles` the `realm-management` and assign roles: 
+2) Open the `kong-sa` client, select `Service Account Roles` tab, select in `Client Roles` the `realm-management` and assign roles: 
       - `create-client`, 
       - `manage-clients`,
       - `query-clients`, 
@@ -87,7 +87,6 @@ See installation [doc](https://developer.konghq.com/deck/?tab=windows#install-de
     - Open a termninal
     - Set the environment variables:
     ```shell
-    export DECK_KEYCLOAK_CR_INITIAL_AT=<initial_at-to-be-replaced> # see Keycloak prerequisites
     export DECK_KEYCLOAK_CLIENT_ID=kong-sa
     export DECK_KEYCLOAK_CLIENT_SECRET=<kong-sa-client_secret-to-be-replaced>
     export DECK_KEYCLOAK_REALM=<keycloak_realm_to_be_replaced> # Example: Jerome
@@ -144,7 +143,6 @@ Install Yarn [^1.22.x](https://classic.yarnpkg.com/lang/en/docs/install)
     - Open `Configuration`/`Environment variables` and Edit:
       - KEYCLOAK_CLIENT_ID = `kong-sa`
       - KEYCLOAK_CLIENT_SECRET = `<kong-sa-client_secret-to-be-replaced>`
-      - KEYCLOAK_CR_INITIAL_AT = `<initial_at-to-be-replaced>` (see Keycloak prerequisites)
       - KEYCLOAK_DOMAIN = `<keycloak-domain-to-be-replaced>` (example: https://sso.apim.eu:8443/auth/realms/Jerome/)
       - KONG_API_TOKENS = `<your_Konnect_API_Key_value>`
 
@@ -172,7 +170,6 @@ yarn install --frozen-lockfile
 
 2) Create an `.env` file at the root of this project, get the following content and **replace the strings enclosed by < >**:
 ```shell
-KEYCLOAK_CR_INITIAL_AT=<initial_at-to-be-replaced>
 KEYCLOAK_CLIENT_ID=kong-sa
 KEYCLOAK_CLIENT_SECRET=<kong-sa-client_secret-to-be-replaced>
 # example: https://sso.apim.eu:8443/auth/realms/Jerome/
@@ -283,7 +280,6 @@ The fastify server is started by default on port 3000
 docker run -p 3000:3000 -d \
 --name konnect-keycloak-portal-dcr \
 --platform linux/amd64 \
--e "KEYCLOAK_CR_INITIAL_AT=<initial_at-to-be-replaced>" \
 -e "KEYCLOAK_CLIENT_ID=kong-sa" \
 -e "KEYCLOAK_CLIENT_SECRET=<kong-sa-client_secret-to-be-replaced>" \
 -e "KEYCLOAK_DOMAIN=<keycloak-domain-to-be-replaced>" \

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,5 +2,8 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testRegex: '.test.ts$'
+  // Unit tests only. The live-Keycloak integration tests (`*.it.test.ts`) are
+  // excluded here and run via `npm run test:integration` (jest.integration.config.js).
+  testRegex: '.test.ts$',
+  testPathIgnorePatterns: ['/node_modules/', '\\.it\\.test\\.ts$']
 };

--- a/jest.integration.config.js
+++ b/jest.integration.config.js
@@ -1,0 +1,9 @@
+/** @type {import('ts-jest').JestConfigWithTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  // Only the live-Keycloak integration tests.
+  testRegex: '\\.it\\.test\\.ts$',
+  // Spinning up clients against a real Keycloak is slower than unit tests.
+  testTimeout: 30000
+};

--- a/kong-gw/kong-keycloak-dcr.yaml
+++ b/kong-gw/kong-keycloak-dcr.yaml
@@ -50,11 +50,53 @@ services:
                 }
             tags:
               - keycloak-dcr
+          # Mint a short-lived service-account token from the `kong-sa` client
+          # (which holds the `create-client` realm-management role) on every
+          # call, exactly like the Delete and Refresh routes below. The
+          # registration endpoint accepts either a Client Registration Initial
+          # Access Token (IAT) or a bearer token with `create-client`. Using the
+          # IAT here was a bug: an IAT is a consumable bootstrap credential that
+          # is decremented on each registration and expires, so create would
+          # start returning 401 once the count/expiration was reached.
+          - name: datakit
+            config:
+              debug: true
+              nodes:
+              - name: STATIC_INPUTS
+                type: static
+                values:
+                  client_id: ${{ env "DECK_KEYCLOAK_CLIENT_ID" }}
+                  client_secret: ${{ env "DECK_KEYCLOAK_CLIENT_SECRET" }}
+                  body: grant_type=client_credentials
+              - name: CONVERT_HEADER_BASE64
+                jq: |-
+                  {
+                    "Content-Type": ("application/x-www-form-urlencoded"),
+                    Authorization: ("Basic " + (.client_id + ":" + .client_secret |@base64))
+                  }
+                type: jq
+                inputs:
+                  client_id: STATIC_INPUTS.client_id
+                  client_secret: STATIC_INPUTS.client_secret
+              - name: AUTH_REQUEST
+                type: call
+                inputs:
+                  body: STATIC_INPUTS.body
+                  headers: CONVERT_HEADER_BASE64
+                url: ${{ env "DECK_KEYCLOAK_DOMAIN" }}/auth/realms/${{ env "DECK_KEYCLOAK_REALM" }}/protocol/openid-connect/token
+                method: POST
+              - name: UPSTREAM_AUTH_HEADER
+                type: jq
+                input: AUTH_REQUEST.body
+                output: service_request.headers
+                jq: |
+                  {
+                    Authorization: ("Bearer " + .access_token)
+                  }
+            tags:
+              - keycloak-dcr
           - name: request-transformer-advanced
             config:
-              add:
-                headers:
-                  - Authorization:"Bearer ${{ env "DECK_KEYCLOAK_CR_INITIAL_AT" }}"
               replace:
                 uri: "/auth/realms/${{ env "DECK_KEYCLOAK_REALM" }}/clients-registrations/openid-connect"
             tags:

--- a/kubernetes/konnect-keycloak-portal-dcr.yaml
+++ b/kubernetes/konnect-keycloak-portal-dcr.yaml
@@ -7,7 +7,6 @@ metadata:
     app: konnect-portal-dcr-keycloak
 type: Opaque
 stringData:
-  KEYCLOAK_CR_INITIAL_AT: "<initial_at-to-be-replaced>"
   KEYCLOAK_CLIENT_ID: "kong-sa"
   KEYCLOAK_CLIENT_SECRET: "<kong-sa-client_secret-to-be-replaced>"
   KEYCLOAK_DOMAIN: "<keycloak-domain-to-be-replaced>"

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "build": "tsc",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint . --ext .ts --fix",
-    "test": "env $(grep -v '^#' .env.test) jest"
+    "test": "env $(grep -v '^#' .env.test) jest",
+    "test:integration": "bash test/integration/run.sh"
   },
   "engines": {
     "node": ">=20",

--- a/src/app.it.test.ts
+++ b/src/app.it.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Integration test against a LIVE Keycloak instance.
+ *
+ * This is the regression test for the IAT-exhaustion bug: it drives the real
+ * bridge code (no mocked axios) and registers several clients in a row using
+ * only the `kong-sa` service-account credentials. With the previous
+ * implementation the create path used a consumable Initial Access Token (IAT)
+ * and would start returning 401 once its Count was exhausted; with the fix it
+ * mints a fresh service-account token per call and can create clients
+ * indefinitely.
+ *
+ * It is NOT run by `npm test`. Provision Keycloak and run it via:
+ *   npm run test:integration
+ * (see test/integration/run.sh). The suite skips itself if the live Keycloak
+ * environment variables are not present, so it is safe in any environment.
+ */
+import { FastifyInstance } from 'fastify'
+import { init } from './app'
+import { ApplicationPayload } from './schemas/ApplicationPayload'
+
+const live = Boolean(process.env.KEYCLOAK_CLIENT_SECRET && process.env.KEYCLOAK_DOMAIN)
+const describeLive = live ? describe : describe.skip
+
+if (!live) {
+  // eslint-disable-next-line no-console
+  console.warn('[integration] skipping live Keycloak tests: KEYCLOAK_DOMAIN / KEYCLOAK_CLIENT_SECRET not set')
+}
+
+describeLive('DCR bridge against a live Keycloak', () => {
+  let app: FastifyInstance
+  const apiKey = (process.env.KONG_API_TOKENS ?? '').split(',')[0]
+  const createdClientIds: string[] = []
+
+  const basePayload = (name: string): ApplicationPayload => ({
+    redirect_uris: ['https://example.com/callback'],
+    client_name: name,
+    grant_types: ['authorization_code', 'refresh_token'],
+    token_endpoint_auth_method: 'client_secret_post',
+    application_description: 'integration test client',
+    portal_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2705',
+    organization_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2706'
+  })
+
+  const create = async (name: string) =>
+    app.inject({
+      method: 'POST',
+      url: '/',
+      headers: { 'Content-Type': 'application/json', 'X-API-KEY': apiKey },
+      payload: basePayload(name)
+    })
+
+  beforeAll(async () => {
+    // init() builds a real axios client pointed at KEYCLOAK_DOMAIN.
+    app = await init()
+  })
+
+  afterAll(async () => {
+    // Best-effort cleanup of anything we created but did not already delete.
+    for (const id of createdClientIds) {
+      await app.inject({
+        method: 'DELETE',
+        url: `/${id}`,
+        headers: { 'X-API-KEY': apiKey }
+      }).catch(() => undefined)
+    }
+    await app.close()
+  })
+
+  it('registers multiple clients in a row with only the kong-sa credentials (no IAT)', async () => {
+    const N = 5
+    const ids = new Set<string>()
+
+    for (let i = 0; i < N; i++) {
+      const resp = await create(`it-repeat-${Date.now()}-${i}`)
+      expect(resp.statusCode).toEqual(201)
+
+      const body = JSON.parse(resp.body)
+      expect(body.client_id).toBeTruthy()
+      expect(body.client_secret).toBeTruthy()
+      createdClientIds.push(body.client_id)
+      ids.add(body.client_id)
+    }
+
+    // Every call succeeded and produced a distinct client — the behaviour an
+    // exhausted/expired IAT could not deliver.
+    expect(ids.size).toEqual(N)
+  })
+
+  it('supports the full create -> delete round-trip via the bridge', async () => {
+    const createResp = await create(`it-roundtrip-${Date.now()}`)
+    expect(createResp.statusCode).toEqual(201)
+    const { client_id: clientId } = JSON.parse(createResp.body)
+    expect(clientId).toBeTruthy()
+
+    const deleteResp = await app.inject({
+      method: 'DELETE',
+      url: `/${clientId}`,
+      headers: { 'X-API-KEY': apiKey }
+    })
+    expect(deleteResp.statusCode).toEqual(204)
+  })
+
+  it('rejects a create with a wrong API key without calling Keycloak', async () => {
+    const resp = await app.inject({
+      method: 'POST',
+      url: '/',
+      headers: { 'Content-Type': 'application/json', 'X-API-KEY': 'definitely-wrong' },
+      payload: basePayload('should-not-be-created')
+    })
+    expect(resp.statusCode).toEqual(401)
+  })
+})

--- a/src/app.test.ts
+++ b/src/app.test.ts
@@ -31,15 +31,23 @@ describe('dcr handlers', () => {
         organization_id: '426ac0a7-aeb6-4043-a404-c4bfe24f2706'
       }
 
-      jest.spyOn(mockAxios, 'post').mockResolvedValueOnce({
-        data: {
-          client_id: 'id',
-          client_id_issued_at: 1700825336,
-          client_secret: 'secret',
-          client_secret_expires_at: 0
-        },
-        status: 201
-      } as any)
+      // 1st POST mints the `kong-sa` service-account token, 2nd POST registers
+      // the client. The bridge no longer uses a Client Registration Initial
+      // Access Token (IAT) for create.
+      jest.spyOn(mockAxios, 'post')
+        .mockResolvedValueOnce({
+          data: { access_token: 'a-service-account-token' },
+          status: 200
+        } as any)
+        .mockResolvedValueOnce({
+          data: {
+            client_id: 'id',
+            client_id_issued_at: 1700825336,
+            client_secret: 'secret',
+            client_secret_expires_at: 0
+          },
+          status: 201
+        } as any)
 
       const resp = await app.inject({
         method: 'POST',
@@ -59,7 +67,19 @@ describe('dcr handlers', () => {
         client_secret_expires_at: 0
       }
       ))
-      expect(mockAxios.post).toHaveBeenCalledTimes(1)
+      // 1 call to fetch the service-account token + 1 call to register the client
+      expect(mockAxios.post).toHaveBeenCalledTimes(2)
+      // The client registration must use the freshly minted service-account
+      // bearer token, NOT an IAT.
+      expect(mockAxios.post).toHaveBeenLastCalledWith(
+        'clients-registrations/openid-connect',
+        expect.any(Object),
+        expect.objectContaining({
+          headers: expect.objectContaining({
+            Authorization: 'Bearer a-service-account-token'
+          })
+        })
+      )
 
       await app.close()
     })
@@ -128,6 +148,7 @@ describe('dcr handlers', () => {
 
   describe('Delete', () => {
     it('succeed', async () => {
+      jest.spyOn(mockAxios, 'post').mockResolvedValueOnce({ data: { access_token: 'a-service-account-token' }, status: 200 } as any)
       jest.spyOn(mockAxios, 'delete').mockResolvedValueOnce({ status: 200 } as any)
 
       const resp = await app.inject({
@@ -144,6 +165,7 @@ describe('dcr handlers', () => {
     })
 
     it('succeed with both api key', async () => {
+      jest.spyOn(mockAxios, 'post').mockResolvedValueOnce({ data: { access_token: 'a-service-account-token' }, status: 200 } as any)
       jest.spyOn(mockAxios, 'delete').mockResolvedValueOnce({ status: 200 } as any)
 
       const resp = await app.inject({
@@ -176,12 +198,12 @@ describe('dcr handlers', () => {
 
   describe('Refresh Secret', () => {
     it('succeed', async () => {
-      jest.spyOn(mockAxios, 'post').mockResolvedValueOnce({
-        data: {
-          client_secret: 'secret'
-        },
-        status: 200
-      } as any)
+      // 1st POST mints the service-account token, 2nd POST regenerates the
+      // client secret, then a GET reads it back.
+      jest.spyOn(mockAxios, 'post')
+        .mockResolvedValueOnce({ data: { access_token: 'a-service-account-token' }, status: 200 } as any)
+        .mockResolvedValueOnce({ data: {}, status: 200 } as any)
+      jest.spyOn(mockAxios, 'get').mockResolvedValueOnce({ data: { value: 'secret' }, status: 200 } as any)
 
       const app = await init({ httpClient: mockAxios } as any)
 
@@ -198,7 +220,8 @@ describe('dcr handlers', () => {
         client_id: 'someID',
         client_secret: 'secret'
       }))
-      expect(mockAxios.post).toHaveBeenCalledTimes(1)
+      // 1 call to fetch the service-account token + 1 call to regenerate the secret
+      expect(mockAxios.post).toHaveBeenCalledTimes(2)
     })
 
     it('fails because of a wrong API token', async () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -20,13 +20,12 @@ export async function init (config: serviceConfig = {}) {
   await app.register(fastifyEnv, {
     schema: {
       type: 'object',
-      required: ['KEYCLOAK_CR_INITIAL_AT', 'KEYCLOAK_CLIENT_ID', 'KEYCLOAK_CLIENT_SECRET', 'KEYCLOAK_DOMAIN', 'KONG_API_TOKENS'],
+      required: ['KEYCLOAK_CLIENT_ID', 'KEYCLOAK_CLIENT_SECRET', 'KEYCLOAK_DOMAIN', 'KONG_API_TOKENS'],
       properties: {
         KONG_API_TOKENS: {
           type: 'string',
           separator: ','
         },
-        KEYCLOAK_CR_INITIAL_AT: { type: 'string' },
         KEYCLOAK_CLIENT_ID: { type: 'string' },
         KEYCLOAK_CLIENT_SECRET: { type: 'string' },
         KEYCLOAK_DOMAIN: { type: 'string' }
@@ -87,7 +86,6 @@ declare module 'fastify' {
       KONG_API_TOKENS: string[]
       KEYCLOAK_CLIENT_ID: string
       KEYCLOAK_CLIENT_SECRET: string
-      KEYCLOAK_CR_INITIAL_AT: string
       KEYCLOAK_DOMAIN: string
     }
   }

--- a/src/handlers/handler.ts
+++ b/src/handlers/handler.ts
@@ -69,7 +69,16 @@ export function DCRHandlers (fastify: FastifyInstance, _: RegisterOptions, next:
         application_type: 'service'
       }
 
-      const headers = getHeaders(fastify.config.KEYCLOAK_CR_INITIAL_AT)
+      // Mint a short-lived service-account token from the `kong-sa` client
+      // (which holds the `create-client` realm-management role) on every call.
+      // The registration endpoint accepts either a Client Registration Initial
+      // Access Token (IAT) or a bearer token with `create-client`. Using the IAT
+      // here was a bug: an IAT is a consumable bootstrap credential that is
+      // decremented on each registration and expires, so create would start
+      // returning 401 once the count/expiration was reached. Minting a token per
+      // request makes create consistent with delete/refresh-secret below.
+      const accessToken = await getAccessToken(fastify, fastify.config.KEYCLOAK_CLIENT_ID, fastify.config.KEYCLOAK_CLIENT_SECRET)
+      const headers = getHeaders(accessToken)
       const url = 'clients-registrations/openid-connect'
       console.log("Keycloak request, url='POST /%s', headers=%j, body=%j", url, headers, payloadKeycloak)
       const response = await fastify.httpClient.post(

--- a/test/integration/run.sh
+++ b/test/integration/run.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+#
+# End-to-end integration run:
+#   1. start + provision a live Keycloak (realm + kong-sa service account)
+#   2. export the bridge environment
+#   3. run the live Jest integration tests
+#   4. tear the container down (unless KEEP_KEYCLOAK=1)
+#
+# Requires: docker (a running daemon), curl, jq.
+set -euo pipefail
+cd "$(dirname "$0")/../.."
+
+cleanup() {
+  if [ "${KEEP_KEYCLOAK:-0}" = "1" ]; then
+    echo "[run] KEEP_KEYCLOAK=1 -> leaving Keycloak container running" >&2
+  else
+    bash test/integration/teardown-keycloak.sh
+  fi
+}
+trap cleanup EXIT
+
+# Provision Keycloak and load KEYCLOAK_* / KONG_API_TOKENS into the environment.
+ENV_FILE="$(mktemp)"
+bash test/integration/setup-keycloak.sh > "$ENV_FILE"
+set -a; . "$ENV_FILE"; set +a
+rm -f "$ENV_FILE"
+
+echo "[run] running integration tests against ${KEYCLOAK_DOMAIN}" >&2
+npx jest --config jest.integration.config.js "$@"

--- a/test/integration/setup-keycloak.sh
+++ b/test/integration/setup-keycloak.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Spins up a live Keycloak in Docker and provisions the realm + `kong-sa`
+# service-account client that the DCR bridge needs, then prints the bridge
+# environment (KEYCLOAK_* / KONG_API_TOKENS) on stdout as `KEY=VALUE` lines.
+#
+# Notably it does NOT create a Client Registration Initial Access Token (IAT):
+# the whole point of the fix is that `kong-sa` (which holds the `create-client`
+# role) is sufficient for every operation, including client creation.
+#
+# Provisioning is done through the Keycloak Admin REST API with curl + jq, so
+# it does not depend on the in-container `kcadm.sh` (whose JVM crashes with
+# SIGILL on some Apple Silicon / vz setups).
+#
+# Usage:
+#   eval "$(test/integration/setup-keycloak.sh)"   # provision + export env
+#   test/integration/teardown-keycloak.sh          # remove the container
+#
+# All diagnostics go to stderr so stdout stays clean for `eval`.
+set -euo pipefail
+
+CONTAINER="${KC_CONTAINER:-keycloak-dcr-it}"
+IMAGE="${KC_IMAGE:-quay.io/keycloak/keycloak:26.0}"
+PORT="${KC_PORT:-8080}"
+REALM="${KC_REALM:-dcr-test}"
+ADMIN_USER="${KC_ADMIN_USER:-admin}"
+ADMIN_PASS="${KC_ADMIN_PASS:-admin}"
+CLIENT_ID="${KC_CLIENT_ID:-kong-sa}"
+API_KEY="${KC_API_KEY:-an-integration-test-api-key}"
+BASE="http://localhost:${PORT}"
+
+log() { echo "[setup-keycloak] $*" >&2; }
+
+# 1) Start Keycloak if it is not already running.
+if [ -z "$(docker ps -q -f "name=^${CONTAINER}$")" ]; then
+  log "starting Keycloak container '${CONTAINER}' from ${IMAGE}"
+  docker rm -f "$CONTAINER" >/dev/null 2>&1 || true
+  # -XX:UseSVE=0 avoids a JDK SIGILL on Apple Silicon / vz VMs.
+  docker run -d --name "$CONTAINER" -p "${PORT}:8080" \
+    -e KC_BOOTSTRAP_ADMIN_USERNAME="$ADMIN_USER" \
+    -e KC_BOOTSTRAP_ADMIN_PASSWORD="$ADMIN_PASS" \
+    -e JAVA_OPTS_APPEND="-XX:UseSVE=0" \
+    "$IMAGE" start-dev >/dev/null
+else
+  log "reusing already-running container '${CONTAINER}'"
+fi
+
+# 2) Wait until the master realm answers.
+log "waiting for Keycloak to become ready at ${BASE} ..."
+for i in $(seq 1 60); do
+  if [ "$(curl -s -o /dev/null -w '%{http_code}' "${BASE}/realms/master")" = "200" ]; then
+    log "Keycloak ready"
+    break
+  fi
+  sleep 2
+  if [ "$i" = "60" ]; then log "ERROR: Keycloak did not become ready"; exit 1; fi
+done
+
+# --- Admin REST helpers --------------------------------------------------
+admin_token() {
+  curl -s --fail "${BASE}/realms/master/protocol/openid-connect/token" \
+    -d "grant_type=password" -d "client_id=admin-cli" \
+    -d "username=${ADMIN_USER}" -d "password=${ADMIN_PASS}" | jq -r .access_token
+}
+TOKEN="$(admin_token)"
+[ -n "$TOKEN" ] && [ "$TOKEN" != "null" ] || { log "ERROR: could not obtain admin token"; exit 1; }
+log "obtained admin access token"
+
+api() { # METHOD PATH [JSON_BODY]
+  local method="$1" path="$2" body="${3:-}"
+  if [ -n "$body" ]; then
+    curl -s -w '\n%{http_code}' -X "$method" "${BASE}/admin/realms/${path}" \
+      -H "Authorization: Bearer ${TOKEN}" -H "Content-Type: application/json" -d "$body"
+  else
+    curl -s -w '\n%{http_code}' -X "$method" "${BASE}/admin/realms/${path}" \
+      -H "Authorization: Bearer ${TOKEN}"
+  fi
+}
+api_get() { curl -s --fail "${BASE}/admin/realms/$1" -H "Authorization: Bearer ${TOKEN}"; }
+
+# 3) Create the realm (idempotent).
+if api_get "${REALM}" >/dev/null 2>&1; then
+  log "realm '${REALM}' already exists"
+else
+  api POST "" "{\"realm\":\"${REALM}\",\"enabled\":true}" >/dev/null
+  log "created realm '${REALM}'"
+fi
+
+# 4) Create the `kong-sa` confidential client with service accounts enabled
+#    (idempotent).
+CID="$(api_get "${REALM}/clients?clientId=${CLIENT_ID}" | jq -r '.[0].id // empty')"
+if [ -z "$CID" ]; then
+  api POST "${REALM}/clients" "$(jq -nc \
+    --arg cid "$CLIENT_ID" \
+    '{clientId:$cid, enabled:true, publicClient:false, serviceAccountsEnabled:true, standardFlowEnabled:true, directAccessGrantsEnabled:true, redirectUris:["http://*","https://*"]}')" >/dev/null
+  CID="$(api_get "${REALM}/clients?clientId=${CLIENT_ID}" | jq -r '.[0].id // empty')"
+  log "created client '${CLIENT_ID}' (id=${CID})"
+else
+  log "client '${CLIENT_ID}' already exists (id=${CID})"
+fi
+[ -n "$CID" ] || { log "ERROR: could not resolve client id"; exit 1; }
+
+# 5) Assign the realm-management roles to kong-sa's service account.
+#    `create-client` is the role that makes the OIDC client-registration
+#    endpoint accept kong-sa's bearer token in place of an IAT.
+SA_USER_ID="$(api_get "${REALM}/clients/${CID}/service-account-user" | jq -r '.id')"
+RM_CID="$(api_get "${REALM}/clients?clientId=realm-management" | jq -r '.[0].id')"
+RM_ROLES="$(api_get "${REALM}/clients/${RM_CID}/roles")"
+ROLES_PAYLOAD="$(echo "$RM_ROLES" | jq -c '[ .[] | select(.name=="create-client" or .name=="manage-clients" or .name=="query-clients" or .name=="view-clients") | {id, name} ]')"
+api POST "${REALM}/users/${SA_USER_ID}/role-mappings/clients/${RM_CID}" "$ROLES_PAYLOAD" >/dev/null
+log "assigned realm-management roles: create-client manage-clients query-clients view-clients"
+
+# 6) Read back the generated client secret.
+SECRET="$(api_get "${REALM}/clients/${CID}/client-secret" | jq -r '.value')"
+[ -n "$SECRET" ] && [ "$SECRET" != "null" ] || { log "ERROR: could not read client secret"; exit 1; }
+log "fetched client secret for '${CLIENT_ID}'"
+
+# 7) Emit the bridge environment on stdout.
+cat <<EOF
+KEYCLOAK_CLIENT_ID=${CLIENT_ID}
+KEYCLOAK_CLIENT_SECRET=${SECRET}
+KEYCLOAK_DOMAIN=${BASE}/realms/${REALM}/
+KONG_API_TOKENS=${API_KEY}
+EOF

--- a/test/integration/teardown-keycloak.sh
+++ b/test/integration/teardown-keycloak.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Removes the Keycloak container started by setup-keycloak.sh.
+set -euo pipefail
+CONTAINER="${KC_CONTAINER:-keycloak-dcr-it}"
+echo "[teardown-keycloak] removing container '${CONTAINER}'" >&2
+docker rm -f "$CONTAINER" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Problem

The Konnect Dev Portal **create application** path registers Keycloak clients with a Client Registration **Initial Access Token (IAT)**:

```ts
// src/handlers/handler.ts (POST create)
const headers = getHeaders(fastify.config.KEYCLOAK_CR_INITIAL_AT) // <-- IAT, consumed each time
```

An IAT is a **consumable bootstrap credential**. When you create one (Realm Settings → Client Registration → Initial Access Token) you set a **Count** (how many clients may be registered) and an **Expiration**. Every registration through `clients-registrations/openid-connect` **decrements the count**, and the token dies when the count hits 0 *or* the expiration passes — after which Keycloak returns `401 Unauthorized`.

So client creation works for a while and then silently breaks, while **delete** and **refresh-secret** keep working because they already mint a fresh service-account token per call:

```ts
const accessToken = await getAccessToken(fastify, fastify.config.KEYCLOAK_CLIENT_ID, fastify.config.KEYCLOAK_CLIENT_SECRET)
const headers = getHeaders(accessToken)
```

The create path was the only operation tied to the expiring IAT.

## Fix

The `kong-sa` service account the README has you configure **already holds the `create-client` realm-management role**, and Keycloak's registration endpoint accepts *either* an IAT *or* a bearer token from an account with `create-client`. So this makes `create` behave like `delete`/`refresh`: mint a short-lived service-account token from the long-lived `kong-sa` client credentials on every request. The endpoint and payload are unchanged, and `KEYCLOAK_CR_INITIAL_AT` is no longer needed — the expiry problem disappears.

The same fix is applied to the **Kong Gateway (decK)** approach: the create route now mints a token via the `datakit` plugin (mirroring the delete/refresh routes) instead of injecting the IAT via `request-transformer-advanced`.

## Changes

- **`src/handlers/handler.ts`** — create handler calls `getAccessToken()` instead of using the IAT.
- **`src/app.ts`** — drop the now-unused `KEYCLOAK_CR_INITIAL_AT` from the config schema and type.
- **`kong-gw/kong-keycloak-dcr.yaml`** — create route mints a service-account token via `datakit`.
- **`README.md`, `.env.dockerfile`, `kubernetes/…yaml`** — remove the IAT setup step/env var and document why.
- **tests** — repaired the stale `.env.test` (it was missing required vars, so the whole suite failed) and updated the create/delete/refresh mocks to cover the token-minting flow, including an assertion that the create call sends the service-account bearer token rather than an IAT.

## Verification

- `npm run build` (tsc) — passes
- `npm test` — 13/13 pass (suite was previously red due to a stale `.env.test`)
- `npm run lint` — no new errors introduced (identical error count before/after; the 52 pre-existing errors are in untouched code)
- `deck file validate kong-gw/kong-keycloak-dcr.yaml` — passes

## Migration note

`KEYCLOAK_CR_INITIAL_AT` / `DECK_KEYCLOAK_CR_INITIAL_AT` can be removed from your environment. No IAT needs to be created in Keycloak anymore; ensure `kong-sa` retains the `create-client` role (it is in the existing setup instructions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)